### PR TITLE
Improve initials regexes

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -31,11 +31,11 @@ not_na_any <- function(cols) {
 }
 
 dot <- function(x) {
-  string_replace_all(x, "(?<=\\pL)", ".")
+  string_replace_all(x, "(*UCP)(?<=\\w(?!\\p{Po}))", ".")
 }
 
 make_initials <- function(x, dot = FALSE) {
-  out <- string_remove_all(x, "[^\\p{Lu}-]+")
+  out <- string_remove_all(x, "(*UCP)\\B\\w+|\\s+")
   if (dot) {
     out <- dot(out)
   }

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -26,14 +26,20 @@ test_that("initialize() ignores variables with the same name as internal ones", 
 })
 
 test_that("initialize() makes proper initials and literal names", {
-  df <- basic_df()
+  df <- data.frame(
+    given_name = c("Zip", "ric", "Pim-Pam", "Tic", "Fip", "12"),
+    family_name = c("Zap", "rac", "Pom", "tac Toc", "A'Fop", "34")
+  )
   aut <- Plume$new(df)
 
-  literal_names <- df$literal_name
-  initials <- make_initials(literal_names)
-
-  expect_equal(aut$get_plume()$initials, initials)
-  expect_equal(aut$get_plume()$literal_name, literal_names)
+  expect_equal(
+    aut$get_plume()$literal_name,
+    paste(df$given_name, df$family_name)
+  )
+  expect_equal(
+    aut$get_plume()$initials,
+    c("ZZ", "rr", "P-PP", "TtT", "FA'F", "13")
+  )
 })
 
 test_that("`affiliation`, `role` and `note` columns are nestable", {


### PR DESCRIPTION
Initials now preserve special characters and are built based on the first word character of any words in the given and family name. This means that initials now handle:
* particles and lowercase names
* numeric characters
* apostrophes