### PR TITLE
Fix `$get_contributions()` parameters

### DIFF
--- a/R/plume.R
+++ b/R/plume.R
@@ -266,7 +266,7 @@ Plume <- R6Class(
       if (!roles_first) {
         format <- rev(format)
       }
-      if (roles_first || !by_author) {
+      if (!by_author) {
         grp_var <- role
         var <- authors
       } else {

--- a/R/plume.R
+++ b/R/plume.R
@@ -156,10 +156,10 @@ Plume <- R6Class(
     },
 
     #' @description Get authors' contributions.
-    #' @param role_first If `TRUE`, displays roles first and authors second. If
+    #' @param roles_first If `TRUE`, displays roles first and authors second. If
     #'   `FALSE`, roles follow authors.
     #' @param name_list Should all authors with the same role be listed
-    #'   together? Only applies when `role_first = FALSE`.
+    #'   together? Only applies when `roles_first = FALSE`.
     #' @param alphabetical_order Should authors be listed in alphabetical order?
     #'   By default, lists authors in the order they are defined.
     #' @param dotted_initials Should initials be dot-separated?
@@ -170,7 +170,7 @@ Plume <- R6Class(
     #'   if more than one item is associated to a role or author.
     #' @return A character vector.
     get_contributions = function(
-        role_first = TRUE,
+        roles_first = TRUE,
         name_list = FALSE,
         alphabetical_order = FALSE,
         dotted_initials = TRUE,
@@ -181,7 +181,7 @@ Plume <- R6Class(
       role <- private$names$role
       private$check_col(role)
       check_args("bool", list(
-        role_first,
+        roles_first,
         name_list,
         alphabetical_order,
         dotted_initials,
@@ -199,7 +199,7 @@ Plume <- R6Class(
       } else {
         authors <- initials
       }
-      pars <- private$contribution_pars(role_first, name_list, authors, divider)
+      pars <- private$contribution_pars(roles_first, name_list, authors, divider)
       if (has_initials && dotted_initials && !literal_names) {
         out <- mutate(out, !!authors := dot(.data[[authors]]))
       }
@@ -255,18 +255,18 @@ Plume <- R6Class(
       as_plm(out)
     },
 
-    contribution_pars = function(role_first, name_list, authors, divider) {
-      if (!role_first && name_list) {
+    contribution_pars = function(roles_first, name_list, authors, divider) {
+      if (!roles_first && name_list) {
         divider <- " "
       } else {
         divider <- divider %||% ": "
       }
       role <- private$names$role
       format <- c(role, authors)
-      if (!role_first) {
+      if (!roles_first) {
         format <- rev(format)
       }
-      if (role_first || name_list) {
+      if (roles_first || name_list) {
         grp_var <- role
         var <- authors
       } else {

--- a/R/plume.R
+++ b/R/plume.R
@@ -170,7 +170,7 @@ Plume <- R6Class(
     #' @return A character vector.
     get_contributions = function(
         roles_first = TRUE,
-        by_author = TRUE,
+        by_author = FALSE,
         alphabetical_order = FALSE,
         dotted_initials = TRUE,
         literal_names = FALSE,

--- a/R/plume.R
+++ b/R/plume.R
@@ -158,20 +158,20 @@ Plume <- R6Class(
     #' @description Get authors' contributions.
     #' @param roles_first If `TRUE`, displays roles first and authors second. If
     #'   `FALSE`, roles follow authors.
-    #' @param name_list Should all authors with the same role be listed
-    #'   together? Only applies when `roles_first = FALSE`.
+    #' @param by_author Should roles be grouped by author? Only applies when
+    #'   `roles_first = FALSE`.
     #' @param alphabetical_order Should authors be listed in alphabetical order?
     #'   By default, lists authors in the order they are defined.
     #' @param dotted_initials Should initials be dot-separated?
     #' @param literal_names Should literal names be used?
     #' @param divider Separator used to separate role items and authors when
-    #'   `name_list = FALSE`. Uses `": "` by default.
+    #'   `by_author = FALSE`. Uses `": "` by default.
     #' @param sep_last Separator used to separate the last two roles or authors
     #'   if more than one item is associated to a role or author.
     #' @return A character vector.
     get_contributions = function(
         roles_first = TRUE,
-        name_list = FALSE,
+        by_author = TRUE,
         alphabetical_order = FALSE,
         dotted_initials = TRUE,
         literal_names = FALSE,
@@ -182,7 +182,7 @@ Plume <- R6Class(
       private$check_col(role)
       check_args("bool", list(
         roles_first,
-        name_list,
+        by_author,
         alphabetical_order,
         dotted_initials,
         literal_names
@@ -199,7 +199,7 @@ Plume <- R6Class(
       } else {
         authors <- initials
       }
-      pars <- private$contribution_pars(roles_first, name_list, authors, divider)
+      pars <- private$contribution_pars(roles_first, by_author, authors, divider)
       if (has_initials && dotted_initials && !literal_names) {
         out <- mutate(out, !!authors := dot(.data[[authors]]))
       }
@@ -255,8 +255,8 @@ Plume <- R6Class(
       as_plm(out)
     },
 
-    contribution_pars = function(roles_first, name_list, authors, divider) {
-      if (!roles_first && name_list) {
+    contribution_pars = function(roles_first, by_author, authors, divider) {
+      if (!roles_first && !by_author) {
         divider <- " "
       } else {
         divider <- divider %||% ": "
@@ -266,7 +266,7 @@ Plume <- R6Class(
       if (!roles_first) {
         format <- rev(format)
       }
-      if (roles_first || name_list) {
+      if (roles_first || !by_author) {
         grp_var <- role
         var <- authors
       } else {

--- a/R/plume.R
+++ b/R/plume.R
@@ -163,8 +163,8 @@ Plume <- R6Class(
     #'   By default, lists authors in the order they are defined.
     #' @param dotted_initials Should initials be dot-separated?
     #' @param literal_names Should literal names be used?
-    #' @param divider Separator used to separate role items and authors when
-    #'   `by_author = FALSE`. Uses `": "` by default.
+    #' @param divider Separator used to separate roles and authors. Uses `": "`
+    #'   by default.
     #' @param sep_last Separator used to separate the last two roles or authors
     #'   if more than one item is associated to a role or author.
     #' @return A character vector.
@@ -174,7 +174,7 @@ Plume <- R6Class(
         alphabetical_order = FALSE,
         dotted_initials = TRUE,
         literal_names = FALSE,
-        divider = NULL,
+        divider = ": ",
         sep_last = NULL
     ) {
       role <- private$names$role
@@ -186,7 +186,8 @@ Plume <- R6Class(
         dotted_initials,
         literal_names
       ))
-      check_args("string", list(sep_last, divider), allow_null = TRUE)
+      check_string(divider)
+      check_string(sep_last, allow_null = TRUE)
       out <- unnest_drop(private$plume, role)
       if (is_empty(out)) {
         return()
@@ -198,7 +199,7 @@ Plume <- R6Class(
       } else {
         authors <- initials
       }
-      pars <- private$contribution_pars(roles_first, by_author, authors, divider)
+      pars <- private$contribution_pars(roles_first, by_author, authors)
       if (has_initials && dotted_initials && !literal_names) {
         out <- mutate(out, !!authors := dot(.data[[authors]]))
       }
@@ -210,7 +211,7 @@ Plume <- R6Class(
         .data[[pars$var]],
         last = sep_last
       ), .by = all_of(pars$grp_var))
-      out <- collapse_cols(out, pars$format, sep = pars$divider)
+      out <- collapse_cols(out, pars$format, sep = divider)
       as_plm(out)
     }
   ),
@@ -254,12 +255,7 @@ Plume <- R6Class(
       as_plm(out)
     },
 
-    contribution_pars = function(roles_first, by_author, authors, divider) {
-      if (!roles_first && !by_author) {
-        divider <- " "
-      } else {
-        divider <- divider %||% ": "
-      }
+    contribution_pars = function(roles_first, by_author, authors) {
       role <- private$names$role
       format <- c(role, authors)
       if (!roles_first) {
@@ -272,7 +268,7 @@ Plume <- R6Class(
         grp_var <- authors
         var <- role
       }
-      list(divider = divider, grp_var = grp_var, var = var, format = format)
+      list(grp_var = grp_var, var = var, format = format)
     }
   )
 )

--- a/R/plume.R
+++ b/R/plume.R
@@ -158,8 +158,7 @@ Plume <- R6Class(
     #' @description Get authors' contributions.
     #' @param roles_first If `TRUE`, displays roles first and authors second. If
     #'   `FALSE`, roles follow authors.
-    #' @param by_author Should roles be grouped by author? Only applies when
-    #'   `roles_first = FALSE`.
+    #' @param by_author Should roles be grouped by author?
     #' @param alphabetical_order Should authors be listed in alphabetical order?
     #'   By default, lists authors in the order they are defined.
     #' @param dotted_initials Should initials be dot-separated?

--- a/README.Rmd
+++ b/README.Rmd
@@ -101,7 +101,7 @@ aut_v <- Plume$new(
 
 aut_v$get_author_list(format = "^a^") |> enumerate(last = ",\n")
 
-aut_v$get_contributions(roles_first = FALSE, name_list = TRUE)
+aut_v$get_contributions(roles_first = FALSE, by_author = TRUE)
 ```
 
 ## Acknowledgements

--- a/README.Rmd
+++ b/README.Rmd
@@ -101,7 +101,7 @@ aut_v <- Plume$new(
 
 aut_v$get_author_list(format = "^a^") |> enumerate(last = ",\n")
 
-aut_v$get_contributions(role_first = FALSE, name_list = TRUE)
+aut_v$get_contributions(roles_first = FALSE, name_list = TRUE)
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ aut_v$get_author_list(format = "^a^") |> enumerate(last = ",\n")
 #> Denis Diderot^a^, Jean-Jacques Rousseau^b^, François-Marie Arouet^b^,
 #> Jean Le Rond d'Alembert^a,c^
 
-aut_v$get_contributions(role_first = FALSE, name_list = TRUE)
+aut_v$get_contributions(roles_first = FALSE, name_list = TRUE)
 #> D.D., J.-J.R., F.-M.A. and J.L.R.d'A. contributed to the Encyclopédie
 #> D.D. and J.L.R.d'A. supervised the project
 ```

--- a/README.md
+++ b/README.md
@@ -185,9 +185,11 @@ aut_v$get_author_list(format = "^a^") |> enumerate(last = ",\n")
 #> Denis Diderot^a^, Jean-Jacques Rousseau^b^, François-Marie Arouet^b^,
 #> Jean Le Rond d'Alembert^a,c^
 
-aut_v$get_contributions(roles_first = FALSE, name_list = TRUE)
-#> D.D., J.-J.R., F.-M.A. and J.L.R.d'A. contributed to the Encyclopédie
-#> D.D. and J.L.R.d'A. supervised the project
+aut_v$get_contributions(roles_first = FALSE, by_author = TRUE)
+#> D.D.: contributed to the Encyclopédie and supervised the project
+#> J.-J.R.: contributed to the Encyclopédie
+#> F.-M.A.: contributed to the Encyclopédie
+#> J.L.R.d'A.: contributed to the Encyclopédie and supervised the project
 ```
 
 ## Acknowledgements

--- a/man/Plume.Rd
+++ b/man/Plume.Rd
@@ -229,7 +229,7 @@ Get authors' contributions.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Plume$get_contributions(
   roles_first = TRUE,
-  by_author = TRUE,
+  by_author = FALSE,
   alphabetical_order = FALSE,
   dotted_initials = TRUE,
   literal_names = FALSE,

--- a/man/Plume.Rd
+++ b/man/Plume.Rd
@@ -233,7 +233,7 @@ Get authors' contributions.
   alphabetical_order = FALSE,
   dotted_initials = TRUE,
   literal_names = FALSE,
-  divider = NULL,
+  divider = ": ",
   sep_last = NULL
 )}\if{html}{\out{</div>}}
 }
@@ -253,8 +253,8 @@ By default, lists authors in the order they are defined.}
 
 \item{\code{literal_names}}{Should literal names be used?}
 
-\item{\code{divider}}{Separator used to separate role items and authors when
-\code{by_author = FALSE}. Uses \code{": "} by default.}
+\item{\code{divider}}{Separator used to separate roles and authors. Uses \code{": "}
+by default.}
 
 \item{\code{sep_last}}{Separator used to separate the last two roles or authors
 if more than one item is associated to a role or author.}

--- a/man/Plume.Rd
+++ b/man/Plume.Rd
@@ -244,8 +244,7 @@ Get authors' contributions.
 \item{\code{roles_first}}{If \code{TRUE}, displays roles first and authors second. If
 \code{FALSE}, roles follow authors.}
 
-\item{\code{by_author}}{Should roles be grouped by author? Only applies when
-\code{roles_first = FALSE}.}
+\item{\code{by_author}}{Should roles be grouped by author?}
 
 \item{\code{alphabetical_order}}{Should authors be listed in alphabetical order?
 By default, lists authors in the order they are defined.}

--- a/man/Plume.Rd
+++ b/man/Plume.Rd
@@ -228,7 +228,7 @@ A character vector.
 Get authors' contributions.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Plume$get_contributions(
-  role_first = TRUE,
+  roles_first = TRUE,
   name_list = FALSE,
   alphabetical_order = FALSE,
   dotted_initials = TRUE,
@@ -241,11 +241,11 @@ Get authors' contributions.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{role_first}}{If \code{TRUE}, displays roles first and authors second. If
+\item{\code{roles_first}}{If \code{TRUE}, displays roles first and authors second. If
 \code{FALSE}, roles follow authors.}
 
 \item{\code{name_list}}{Should all authors with the same role be listed
-together? Only applies when \code{role_first = FALSE}.}
+together? Only applies when \code{roles_first = FALSE}.}
 
 \item{\code{alphabetical_order}}{Should authors be listed in alphabetical order?
 By default, lists authors in the order they are defined.}

--- a/man/Plume.Rd
+++ b/man/Plume.Rd
@@ -229,7 +229,7 @@ Get authors' contributions.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Plume$get_contributions(
   roles_first = TRUE,
-  name_list = FALSE,
+  by_author = TRUE,
   alphabetical_order = FALSE,
   dotted_initials = TRUE,
   literal_names = FALSE,
@@ -244,8 +244,8 @@ Get authors' contributions.
 \item{\code{roles_first}}{If \code{TRUE}, displays roles first and authors second. If
 \code{FALSE}, roles follow authors.}
 
-\item{\code{name_list}}{Should all authors with the same role be listed
-together? Only applies when \code{roles_first = FALSE}.}
+\item{\code{by_author}}{Should roles be grouped by author? Only applies when
+\code{roles_first = FALSE}.}
 
 \item{\code{alphabetical_order}}{Should authors be listed in alphabetical order?
 By default, lists authors in the order they are defined.}
@@ -255,7 +255,7 @@ By default, lists authors in the order they are defined.}
 \item{\code{literal_names}}{Should literal names be used?}
 
 \item{\code{divider}}{Separator used to separate role items and authors when
-\code{name_list = FALSE}. Uses \code{": "} by default.}
+\code{by_author = FALSE}. Uses \code{": "} by default.}
 
 \item{\code{sep_last}}{Separator used to separate the last two roles or authors
 if more than one item is associated to a role or author.}

--- a/tests/testthat/_snaps/get-contributions.md
+++ b/tests/testthat/_snaps/get-contributions.md
@@ -43,17 +43,13 @@
     Code
       (expect_error(aut$get_contributions(sep_last = 1)))
     Output
-      <error/purrr_error_indexed>
-      Error in `map2()`:
-      i In index: 1.
-      Caused by error:
+      <error/rlang_error>
+      Error:
       ! `sep_last` must be a character string.
     Code
       (expect_error(aut$get_contributions(divider = 1)))
     Output
-      <error/purrr_error_indexed>
-      Error in `map2()`:
-      i In index: 2.
-      Caused by error:
+      <error/rlang_error>
+      Error:
       ! `divider` must be a character string.
 

--- a/tests/testthat/_snaps/get-contributions.md
+++ b/tests/testthat/_snaps/get-contributions.md
@@ -1,13 +1,13 @@
 # get_contributions() gives meaningful error messages
 
     Code
-      (expect_error(aut$get_contributions(role_first = "")))
+      (expect_error(aut$get_contributions(roles_first = "")))
     Output
       <error/purrr_error_indexed>
       Error in `map2()`:
       i In index: 1.
       Caused by error:
-      ! `role_first` must be `TRUE` or `FALSE`.
+      ! `roles_first` must be `TRUE` or `FALSE`.
     Code
       (expect_error(aut$get_contributions(name_list = "")))
     Output

--- a/tests/testthat/_snaps/get-contributions.md
+++ b/tests/testthat/_snaps/get-contributions.md
@@ -9,13 +9,13 @@
       Caused by error:
       ! `roles_first` must be `TRUE` or `FALSE`.
     Code
-      (expect_error(aut$get_contributions(name_list = "")))
+      (expect_error(aut$get_contributions(by_author = "")))
     Output
       <error/purrr_error_indexed>
       Error in `map2()`:
       i In index: 2.
       Caused by error:
-      ! `name_list` must be `TRUE` or `FALSE`.
+      ! `by_author` must be `TRUE` or `FALSE`.
     Code
       (expect_error(aut$get_contributions(alphabetical_order = "")))
     Output

--- a/tests/testthat/helper-plume.R
+++ b/tests/testthat/helper-plume.R
@@ -5,6 +5,7 @@ basic_df <- function() {
     given_name = given_names,
     family_name = family_names,
     literal_name = paste(given_names, family_names),
+    initials = c("ZZ", "RR", "P-PP"),
     affiliation = c("a", "c", "d"),
     affiliation2 = c("b", NA, "a"),
     role = rep("a", 3),

--- a/tests/testthat/test-get-contributions.R
+++ b/tests/testthat/test-get-contributions.R
@@ -27,7 +27,7 @@ test_that("get_contributions() return authors' contributions", {
 
   expect_equal(
     aut$get_contributions(roles_first = FALSE, by_author = FALSE),
-    paste0(contributors, " ", roles)
+    paste0(contributors, ": ", roles)
   )
   expect_equal(
     aut$get_contributions(roles_first = TRUE, by_author = FALSE),
@@ -37,8 +37,8 @@ test_that("get_contributions() return authors' contributions", {
   # other arguments
 
   expect_equal(
-    aut$get_contributions(by_author = FALSE, divider = " - "),
-    paste0(roles, " - ", contributors)
+    aut$get_contributions(by_author = FALSE, divider = " "),
+    paste0(roles, " ", contributors)
   )
 
   contributors <- lapply(list_initials, \(x) enumerate(sort(x)))

--- a/tests/testthat/test-get-contributions.R
+++ b/tests/testthat/test-get-contributions.R
@@ -29,7 +29,7 @@ test_that("get_contributions() return authors' contributions", {
   )
   expect_equal(
     aut$get_contributions(
-      role_first = FALSE,
+      roles_first = FALSE,
       name_list = TRUE,
       dotted_initials = FALSE
     ),
@@ -56,7 +56,7 @@ test_that("get_contributions() return authors' contributions", {
   })
 
   expect_equal(
-    aut$get_contributions(role_first = FALSE, literal_names = TRUE),
+    aut$get_contributions(roles_first = FALSE, literal_names = TRUE),
     paste0(literal_names, ": ", roles)
   )
 })
@@ -68,7 +68,7 @@ test_that("get_contributions() gives meaningful error messages", {
 
   expect_snapshot({
     (expect_error(
-      aut$get_contributions(role_first = "")
+      aut$get_contributions(roles_first = "")
     ))
     (expect_error(
       aut$get_contributions(name_list = "")

--- a/tests/testthat/test-get-contributions.R
+++ b/tests/testthat/test-get-contributions.R
@@ -30,7 +30,7 @@ test_that("get_contributions() return authors' contributions", {
   expect_equal(
     aut$get_contributions(
       roles_first = FALSE,
-      name_list = TRUE,
+      by_author = FALSE,
       dotted_initials = FALSE
     ),
     paste0(contributors, " ", roles)
@@ -71,7 +71,7 @@ test_that("get_contributions() gives meaningful error messages", {
       aut$get_contributions(roles_first = "")
     ))
     (expect_error(
-      aut$get_contributions(name_list = "")
+      aut$get_contributions(by_author = "")
     ))
     (expect_error(
       aut$get_contributions(alphabetical_order = "")

--- a/tests/testthat/test-get-contributions.R
+++ b/tests/testthat/test-get-contributions.R
@@ -5,59 +5,70 @@ test_that("get_contributions() return authors' contributions", {
   expect_s3_class(aut$get_contributions(), c("plm_agt", "plm"))
 
   df_roles <- select(df, starts_with("role"))
-
-  initials <- make_initials(df$literal_name)
+  initials <- dot(df$initials)
   list_initials <- list(initials, initials[1])
 
-  roles <- condense(c(df_roles))
-  contributors <- lapply(list_initials, \(x) enumerate(dot(x)))
+  # contributors-roles combinations
+
+  roles <- apply(t(df_roles), 2, \(x) enumerate(na.omit(x)))
+  contributors <- initials
 
   expect_equal(
-    aut$get_contributions(),
+    aut$get_contributions(roles_first = FALSE, by_author = TRUE),
+    paste0(contributors, ": ", roles)
+  )
+  expect_equal(
+    aut$get_contributions(roles_first = TRUE, by_author = TRUE),
     paste0(roles, ": ", contributors)
   )
 
+  roles <- condense(c(df_roles))
   contributors <- lapply(list_initials, enumerate)
 
   expect_equal(
-    aut$get_contributions(dotted_initials = FALSE),
-    paste0(roles, ": ", contributors)
-  )
-  expect_equal(
-    aut$get_contributions(dotted_initials = FALSE, divider = " - "),
-    paste0(roles, " - ", contributors)
-  )
-  expect_equal(
-    aut$get_contributions(
-      roles_first = FALSE,
-      by_author = FALSE,
-      dotted_initials = FALSE
-    ),
+    aut$get_contributions(roles_first = FALSE, by_author = FALSE),
     paste0(contributors, " ", roles)
   )
+  expect_equal(
+    aut$get_contributions(roles_first = TRUE, by_author = FALSE),
+    paste0(roles, ": ", contributors)
+  )
 
-  contributors <- lapply(list_initials, \(x) enumerate(x, last = " & "))
+  # other arguments
 
   expect_equal(
-    aut$get_contributions(dotted_initials = FALSE, sep_last = " & "),
-    paste0(roles, ": ", contributors)
+    aut$get_contributions(by_author = FALSE, divider = " - "),
+    paste0(roles, " - ", contributors)
   )
 
   contributors <- lapply(list_initials, \(x) enumerate(sort(x)))
 
   expect_equal(
-    aut$get_contributions(alphabetical_order = TRUE, dotted_initials = FALSE),
+    aut$get_contributions(by_author = FALSE, alphabetical_order = TRUE),
     paste0(roles, ": ", contributors)
   )
 
-  literal_names <- df$literal_name
-  roles <- apply(t(df_roles), 2, \(x) {
-    enumerate(na.omit(x))
-  })
+  contributors <- lapply(list_initials, \(x) enumerate(x, last = " & "))
 
   expect_equal(
-    aut$get_contributions(roles_first = FALSE, literal_names = TRUE),
-    paste0(literal_names, ": ", roles)
+    aut$get_contributions(by_author = FALSE, sep_last = " & "),
+    paste0(roles, ": ", contributors)
+  )
+
+  list_initials <- list(df$initials, df$initials[1])
+  contributors <- lapply(list_initials, enumerate)
+
+  expect_equal(
+    aut$get_contributions(by_author = FALSE, dotted_initials = FALSE),
+    paste0(roles, ": ", contributors)
+  )
+
+  list_literal_names <- list(df$literal_name, df$literal_name[1])
+  contributors <- lapply(list_literal_names, enumerate)
+
+  expect_equal(
+    aut$get_contributions(by_author = FALSE, literal_names = TRUE),
+    paste0(roles, ": ", contributors)
   )
 })
 

--- a/vignettes/plume.Rmd
+++ b/vignettes/plume.Rmd
@@ -274,10 +274,14 @@ plume provides a convenient way to generate contribution lists using the `get_co
 aut <- Plume$new(encyclopedists, names = c(role = "role_n"))
 aut$get_contributions()
 
-aut$get_contributions(roles_first = FALSE, literal_names = TRUE)
+aut$get_contributions(
+  roles_first = FALSE,
+  by_author = TRUE,
+  literal_names = TRUE
+)
 
 aut_v <- Plume$new(encyclopedists, names = c(role = "role_v"))
-aut_v$get_contributions(roles_first = FALSE, by_author = TRUE)
+aut_v$get_contributions(roles_first = FALSE, divider = " ")
 ```
 
 By default, `get_contributions()` lists contributors in the order they're defined. You can arrange contributors in alphabetical order with `alphabetical_order = TRUE`.

--- a/vignettes/plume.Rmd
+++ b/vignettes/plume.Rmd
@@ -274,10 +274,10 @@ plume provides a convenient way to generate contribution lists using the `get_co
 aut <- Plume$new(encyclopedists, names = c(role = "role_n"))
 aut$get_contributions()
 
-aut$get_contributions(role_first = FALSE, literal_names = TRUE)
+aut$get_contributions(roles_first = FALSE, literal_names = TRUE)
 
 aut_v <- Plume$new(encyclopedists, names = c(role = "role_v"))
-aut_v$get_contributions(role_first = FALSE, name_list = TRUE)
+aut_v$get_contributions(roles_first = FALSE, name_list = TRUE)
 ```
 
 By default, `get_contributions()` lists contributors in the order they're defined. You can arrange contributors in alphabetical order with `alphabetical_order = TRUE`.

--- a/vignettes/plume.Rmd
+++ b/vignettes/plume.Rmd
@@ -277,7 +277,7 @@ aut$get_contributions()
 aut$get_contributions(roles_first = FALSE, literal_names = TRUE)
 
 aut_v <- Plume$new(encyclopedists, names = c(role = "role_v"))
-aut_v$get_contributions(roles_first = FALSE, name_list = TRUE)
+aut_v$get_contributions(roles_first = FALSE, by_author = TRUE)
 ```
 
 By default, `get_contributions()` lists contributors in the order they're defined. You can arrange contributors in alphabetical order with `alphabetical_order = TRUE`.


### PR DESCRIPTION
Fixes ambiguous parameter names and usage in `$get_contributions()`:
* Rename `role_first` and `name_list` to `roles_first` and `by_author`, respectively.
* Remove the `roles_first`-`by_author` dependency, meaning that listing by author when `roles_first = TRUE` is now allowed.
* Remove the `by_author`-`divider` dependency and set the default `divider` value to `": "`.