### PR TITLE
Prevent `to_yaml()` from stripping meta-information

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # plume (development version)
 
+* `$to_yaml()` now writes author metadata in a separate YAML header if the original YAML header contains strippable meta-information such as comments, custom tags or folded blocks (#56, #61).
+
 * The way `$set_*()` methods handle `...` has been reworked for more consistent results and to ensure the methods work correctly in edge cases (#59, #60).
 
 * `vignette("working-in-other-languages")` has been extended to describe how to overwrite default arguments to match your language better.

--- a/R/yaml.R
+++ b/R/yaml.R
@@ -59,10 +59,31 @@ check_has_yaml <- function(x) {
   ))
 }
 
+yaml_has_strippable <- function(x) {
+  pattern <- paste(
+    "\\B#(?=(?:[^'\"]*['\"][^'\"]*['\"])*[^'\"]*$)",
+    ":\\s*(?:>|!!?[a-z]+|&)",
+    sep = "|"
+  )
+  str_detect(x, pattern)
+}
+
+add_yaml_header <- function(x) {
+  rlang::inform(c(
+    "Writing author metadata in a separate YAML header.",
+    i = "This happens because the original YAML contained data such as",
+    "  comments, custom tags or folded blocks that would otherwise be lost."
+  ))
+  c("", "", x)
+}
+
 yaml_push <- function(what, file) {
   text <- read_file(file)
   check_has_yaml(text)
   items <- separate_yaml_header(text)
+  if (yaml_has_strippable(items[[2]])) {
+    items <- add_yaml_header(items)
+  }
   json <- as_json(what)
   json <- json_update(items[[2]], json)
   if (is.null(json)) {

--- a/tests/testthat/_snaps/to-yaml.md
+++ b/tests/testthat/_snaps/to-yaml.md
@@ -195,6 +195,26 @@
       Lorem ipsum
       ---
 
+# to_yaml() writes in a separate header to preserve strippable data (#56)
+
+    Code
+      read_test_file(tmp_file)
+    Output
+      ---
+      author:
+        - id: aut1
+          name:
+            given: Zip
+            family: Zap
+      affiliations: {}
+      ---
+      ---
+      title: test # this is a title
+      foo: >
+        Lorem ipsum
+        Vivamus quis
+      ---
+
 # to_yaml() errors if no YAML headers is found
 
     Code

--- a/tests/testthat/test-to-yaml.R
+++ b/tests/testthat/test-to-yaml.R
@@ -68,6 +68,31 @@ test_that("to_yaml() preserves line breaks preceding `---` (#37)", {
   expect_snapshot(read_test_file(tmp_file))
 })
 
+test_that("to_yaml() writes in a separate header to preserve strippable data (#56)", {
+  tmp_file <- withr::local_tempfile(
+    lines = dedent("
+      ---
+      title: test # this is a title
+      foo: >
+        Lorem ipsum
+        Vivamus quis
+      ---
+    "),
+    fileext = ".qmd"
+  )
+
+  aut <- PlumeQuarto$new(
+    data.frame(given_name = "Zip", family_name = "Zap"),
+    tmp_file
+  )
+
+  expect_message(
+    aut$to_yaml(),
+    "Writing author metadata in a separate YAML header"
+  )
+  expect_snapshot(read_test_file(tmp_file))
+})
+
 # Errors ----
 
 test_that("to_yaml() errors if no YAML headers is found", {


### PR DESCRIPTION
Fixes #56 