### PR TITLE
Only use given name initials if the script allows it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # plume (development version)
 
+* `$new(initials_given_name = TRUE)` no longer makes initials if names are written in a script that doesn't use letter cases (#73).
+
 * Fixed `PlumeQuarto`'s example no longer working with `withr` 3.0.0 due to a wrong usage of `local_tempfile()` (#70).
 
 * `$get_author_list()` now throws a more informative error if corresponding authors have not been set (#69).

--- a/R/plume-handler.R
+++ b/R/plume-handler.R
@@ -135,11 +135,11 @@ PlumeHandler <- R6Class(
     },
 
     add_author_names = function() {
-      if (private$initials_given_name) {
+      if (private$initials_given_name && private$has_uppercase("given_name")) {
         private$make_initials("given_name", dot = TRUE)
       }
       private$add_literal_names()
-      if (any(has_uppercase(private$get("literal_name")))) {
+      if (private$has_uppercase("literal_name")) {
         private$add_initials()
       }
     },
@@ -191,6 +191,10 @@ PlumeHandler <- R6Class(
     is_nestable = function(var) {
       var <- begins_with(var)
       private$has_col(var) && col_count(private$plume, var) > 1L
+    },
+
+    has_uppercase = function(var) {
+      any(has_uppercase(private$get(var)))
     },
 
     has_col = function(col) {

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -120,6 +120,14 @@ test_that("`initials_given_name = TRUE` initialises given names", {
   )
 })
 
+test_that("`initials_given_name` doesn't make initials in scripts not using letter cases (#73)", {
+  aut <- Plume$new(
+    data.frame(given_name = "菖蒲", family_name = "佐藤"),
+    initials_given_name = TRUE
+  )
+  expect_equal(aut$get_plume()$given_name, "菖蒲")
+})
+
 test_that("`family_name_first = TRUE` switches given and family name", {
   aut <- Plume$new(basic_df, family_name_first = TRUE)
   expect_equal(


### PR DESCRIPTION
Fixes #73 

Instead of checking the actual script being used, it actually only makes the initials of given names if at least one given name has one or more capital letters. This is not 100% foolproof but should be sufficient because users are not expected to mix different scripts in real use cases.