### PR TITLE
Remove `inst/CITATION`

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,9 +1,0 @@
-citHeader("To cite plume in publications use:")
-
-bibentry(
-  bibtype  = "Manual",
-  title    = "A Simple Author Handler for Scientific Writing",
-  author   = "Arnaud Gallou",
-  year     = "2023",
-  url      = "https://arnaudgallou.github.io/plume/"
-)


### PR DESCRIPTION
Rely on the default behaviour that generates the citation from the `DESCRIPTION` file instead.

Thanks to @jdblischak for the suggestion.