### PR TITLE
Preserve roles' original case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # plume (development version)
 
+* `PlumeQuarto` no longer converts roles to lower case (#88).
+
 * `PlumeQuarto` now supports authors' `degrees` field and the `group` affiliation property (#53).
 
 * `PlumeQuarto` now properly handles authors with no roles (#81).

--- a/R/plume-quarto.R
+++ b/R/plume-quarto.R
@@ -134,7 +134,7 @@ PlumeQuarto <- R6Class(
         degrees = private$itemise("degree"),
         acknowledgements = private$pull("acknowledgements"),
         attributes = private$author_attributes(),
-        roles = private$itemise("role", to_lower = TRUE),
+        roles = private$itemise("role"),
         metadata = private$author_metadata(),
         affiliations = private$author_affiliations()
       )
@@ -156,8 +156,8 @@ PlumeQuarto <- R6Class(
       out
     },
 
-    itemise = function(var, to_lower = FALSE) {
-      private$pull_nestable(var, \(x) itemise(x, to_lower))
+    itemise = function(var) {
+      private$pull_nestable(var, \(x) list(vec_drop_na(x)))
     },
 
     author_notes = function() {
@@ -240,13 +240,6 @@ PlumeQuarto <- R6Class(
     }
   )
 )
-
-itemise <- function(x, to_lower = FALSE) {
-  if (to_lower) {
-    x <- tolower(x)
-  }
-  list(vec_drop_na(x))
-}
 
 affiliation_keys <- c(
   "number", "name", "department", "address", "city", "region", "state",

--- a/tests/testthat/_snaps/to-yaml.md
+++ b/tests/testthat/_snaps/to-yaml.md
@@ -17,8 +17,8 @@
           attributes:
             corresponding: true
           roles:
-            - formal analysis
-            - writing - original draft
+            - Formal analysis
+            - Writing - original draft
           affiliations:
             - ref: aff1
             - ref: aff2
@@ -31,7 +31,7 @@
           attributes:
             corresponding: false
           roles:
-            - formal analysis
+            - Formal analysis
           affiliations:
             - ref: aff3
         - id: aut3
@@ -43,7 +43,7 @@
           attributes:
             corresponding: false
           roles:
-            - formal analysis
+            - Formal analysis
           affiliations:
             - ref: aff1
             - ref: aff4
@@ -80,7 +80,7 @@
           attributes:
             corresponding: true
           roles:
-            - formal analysis
+            - Formal analysis
           affiliations:
             - ref: aff1
             - ref: aff2
@@ -93,7 +93,7 @@
           attributes:
             corresponding: false
           roles:
-            - formal analysis
+            - Formal analysis
           affiliations:
             - ref: aff3
         - id: aut3
@@ -107,8 +107,8 @@
           attributes:
             corresponding: false
           roles:
-            - formal analysis
-            - writing - original draft
+            - Formal analysis
+            - Writing - original draft
           affiliations:
             - ref: aff2
             - ref: aff4
@@ -243,8 +243,8 @@
             given: A
             family: A
           roles:
-            - formal analysis
-            - writing - original draft
+            - Formal analysis
+            - Writing - original draft
         - id: aut2
           name:
             given: B


### PR DESCRIPTION
It's not necessary to convert roles to lower case because Quarto decorates CRediT roles case insensitively.