### PR TITLE
Tweak `add_long_initials()`

### DIFF
--- a/R/utils-tbl.R
+++ b/R/utils-tbl.R
@@ -105,10 +105,9 @@ rename_roles <- function(data, roles, key) {
 }
 
 add_long_initials <- function(data, col, names) {
-  data[col] <- if_else(
-    vctrs::vec_duplicate_detect(data),
-    lengthen_initials(data[[col]], names),
-    data[[col]]
-  )
+  duplicated <- vctrs::vec_duplicate_detect(data)
+  old <- data[[col]]
+  new <- lengthen_initials(old[duplicated], names[duplicated])
+  data[col] <- replace(old, duplicated, new)
   data
 }

--- a/tests/testthat/test-initialize.R
+++ b/tests/testthat/test-initialize.R
@@ -133,14 +133,25 @@ test_that("`initials_given_name = TRUE` initialises given names", {
 
 test_that("`distinct_initials = TRUE` makes unique initials", {
   df <- data.frame(
-    given_name = c("A", "B", "A", "C", "C", "D", "D"),
-    family_name = c("Dufour", "Fo", "Dupont", "de Rose", "de Reeth", "Ba", "Ba")
+    given_name = c("A", "B", "B", "C", "C"),
+    family_name = c("Foo", "de Rose", "de Reeth", "Bar", "Bar")
   )
   aut <- Plume$new(df, distinct_initials = TRUE)
 
   expect_equal(
     aut$data()$initials,
-    c("A.Duf.", "B.F.", "A.Dup.", "C.d.Ro.", "C.d.Re.", "D.B.", "D.B.")
+    c("A.F.", "B.d.Ro.", "B.d.Re.", "C.B.", "C.B.")
+  )
+
+  df <- data.frame(
+    given_name = c("A", "A", "B"),
+    family_name = c("Dufour", "Delatour", "Dupont")
+  )
+  aut <- Plume$new(df, distinct_initials = TRUE)
+
+  expect_equal(
+    aut$data()$initials,
+    c("A.Du.", "A.De.", "B.D.")
   )
 })
 


### PR DESCRIPTION
This ensures long initials are only generated from names that have duplicated initials.