### PR TITLE
Drop leading `^` when no symbols are displayed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # plume (development version)
 
+* `$get_author_list()` now correctly drops leading `^` when there are no symbols to display (#127).
+
 * ORCID icons are now ignored in Quarto documents. They continue to work in R Markdown as before (#109).
 
 * New `new_plume()` and `new_plume_quarto()` that are aliases for `Plume$new()` and `PlumeQuarto$new()`, respectively (#124).

--- a/R/als.R
+++ b/R/als.R
@@ -23,7 +23,7 @@ als_extract_mark <- function(format, key) {
 }
 
 als_sanitise <- function(x) {
-  str_remove_all(x, "(?<=([,^]))\\1+")
+  str_remove_all(x, "(?<=([,^]))\\1+|^\\^+$")
 }
 
 als_parse <- function(format) {

--- a/tests/testthat/test-get-author-list.R
+++ b/tests/testthat/test-get-author-list.R
@@ -107,6 +107,18 @@ test_that("get_author_list() returns author list", {
   )
 })
 
+test_that("Leading ^ are dropped when there are no symbols to display.", {
+  aut <- Plume$new(tibble::tibble(
+    given_name = "X",
+    family_name = "Y",
+    note = NA
+  ))
+  expect_equal(
+    aut$get_author_list("^n^"),
+    "X Y"
+  )
+})
+
 test_that("get_author_list() makes ORCID icons", {
   aut <- Plume$new(basic_df)
   expect_snapshot(aut$get_author_list("o"), transform = scrub_icon_path)


### PR DESCRIPTION
Fixes #127